### PR TITLE
ModemConfig: Statically link SomcModemProperties

### DIFF
--- a/ModemConfig/Android.bp
+++ b/ModemConfig/Android.bp
@@ -9,7 +9,7 @@ android_app {
 
     required: ["privapp_whitelist_com.sony.opentelephony.modemconfig"],
 
-    libs: ["SomcModemProperties"],
+    static_libs: ["SomcModemProperties"],
 
     sdk_version: "system_current",
 }


### PR DESCRIPTION
Fixes: "Failed resolution of: Lcom/sony/opentelephony/modemconfig/SomcModemProperties;"